### PR TITLE
fix crash when reading set on insert map object

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -249,9 +249,12 @@ func (d *Db) findAndModify(dbName string, query *protocol.OpQuery, reply *protoc
 		}
 	}
 	if nbUpdated == 0 && upsert {
+		var setOnInsertValues bson.D
 		_, col := d.ensureExist(dbName, colName)
 		newDoc := update.Map()["$set"].(bson.D)
-		setOnInsertValues := update.Map()["$setOnInsert"].(bson.D)
+		if _, ok := update.Map()["$setOnInsert"]; ok {
+			setOnInsertValues = update.Map()["$setOnInsert"].(bson.D)
+		}
 		id := queryParam.Map()["_id"]
 		if id == nil {
 			id = fmt.Sprintf("%v", time.Now().UnixMicro())

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -12,6 +12,8 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
+var _ driver.Connection = (*TestConnection)(nil)
+
 type TestConnection struct {
 	database     *db.Db
 	responseChan chan ([]byte)


### PR DESCRIPTION
A crash was introduced in a previous commit.
I did not check for a nil pointer before casting to `bson.D`.

I added a line to check if our code is compatible with the mongo client interface. This will help us ensure compatibility before compiling and pushing new code, especially when upgrading the mongo client in the future.